### PR TITLE
Allowing specification of an exact version to install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 #
 # $install_channel::         Specify REX-Ray channel to install from.
 #                            One of 'stable', 'unstable', 'staged'.
+# 
+# $install_version::         Specify an exact version to install.  If not specified, 
+#                            defaults to the latest from the channel
 #
 # $start_service::           Whether to enable and start REX-Ray as a service
 #
@@ -89,6 +92,7 @@
 #
 class rexray (
   $install_channel          = $rexray::params::install_channel,
+  $install_version          = $rexray::params::install_version,
   $start_service            = $rexray::params::start_service,
   $storage_drivers          = $rexray::params::storage_drivers,
   $aws_accesskey            = $rexray::params::aws_accesskey,
@@ -164,11 +168,20 @@ class rexray (
     ensure => installed,
   }
 
-  exec {'install-rexray':
-    command => 'curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s $install_channel - ',
-    path    => '/usr/bin',
-    require => Package['curl'],
-    creates => '/usr/bin/rexray',
+  if $install_version != '' {
+    exec {'install-rexray':
+      command => "curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s -- ${install_channel} ${install_version}",
+      path    => '/usr/bin',
+      require => Package['curl'],
+      creates => '/usr/bin/rexray',
+    }  
+  } else {
+    exec {'install-rexray':
+      command => "curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s -- $install_channel",
+      path    => '/usr/bin',
+      require => Package['curl'],
+      creates => '/usr/bin/rexray',
+    }  
   }
 
   file {'/etc/rexray/config.yml':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 
 class rexray::params {
   $install_channel  = 'stable'
+  $install_version = ''
   $start_service    = false
   $storage_drivers  = []
 


### PR DESCRIPTION
With the release of the 0.4.x series on the stable channel, it's helpful to be able to specify 0.3.x version numbers.  This patch allows that.  
